### PR TITLE
Update plot_perf.py

### DIFF
--- a/examples/active_learning/plot_perf.py
+++ b/examples/active_learning/plot_perf.py
@@ -1,8 +1,9 @@
 import matplotlib as mpl
-import matplotlib.pyplot as plt
 from io import BytesIO
 import base64
 mpl.use('Agg')
+import matplotlib.pyplot as plt
+
 
 def plot_performance(performance_history):
     fig, ax = plt.subplots(figsize=(8.5, 6), dpi=130)


### PR DESCRIPTION
Make sure matplotlib.use is called before import pyplot
Before this PR when running code from examples/active_learning in virtual env I would be getting error
```
File "main.py", line 12, in <module>
    from plot_perf import plot_performance
  File "/trunklucator/examples/active_learning/plot_perf.py", line 2, in <module>
    import matplotlib.pyplot as plt
  File "/trunklucator/venv/lib/python3.7/site-packages/matplotlib/pyplot.py", line 2372, in <module>
    switch_backend(rcParams["backend"])
  File "/trunklucator/venv/lib/python3.7/site-packages/matplotlib/pyplot.py", line 207, in switch_backend
    backend_mod = importlib.import_module(backend_name)
  File "/trunklucator/venv/lib/python3.7/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "/trunklucator/venv/lib/python3.7/site-packages/matplotlib/backends/backend_macosx.py", line 14, in <module>
    from matplotlib.backends import _macosx
ImportError: Python is not installed as a framework. The Mac OS X backend will not be able to function correctly if Python is not installed as a framework…
```

This is google driven fix brought by [this post](https://markhneedham.com/blog/2018/05/04/python-runtime-error-osx-matplotlib-not-installed-as-framework-mac/)

