### PR TITLE
Examples/active_learning: Have skip exclude extra item from X_pool

### DIFF
--- a/examples/active_learning/main.py
+++ b/examples/active_learning/main.py
@@ -66,6 +66,8 @@ with trunklucator.WebUI() as tru:
         y = tru.ask({"html":"<pre>{}</pre>".format(text)}, meta=META) # We are waiting for human action here
 
         if y == -1:
+            # Remove the skipped instance from the unlabeled pool.
+            X_pool = np.delete(X_pool, query_index, axis=0)
             continue
 
         print(twenty_train.target_names[y])


### PR DESCRIPTION
Given `learner.query` is returning same thing every time for the same X_pool, skip doesn't work in active_learning example, this is my attempt at fixing that